### PR TITLE
Reapply improvements to the tex rendering pipeline

### DIFF
--- a/templates/md2pdf.tpl
+++ b/templates/md2pdf.tpl
@@ -7,6 +7,9 @@
 \usepackage{graphicx}
 \usepackage{microtype}
 \usepackage{hyperref}
+{{#:tex_deps}}
+{{{ :tex_deps }}}
+{{/:tex_deps}}
 
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{1.2ex}


### PR DESCRIPTION
This PR provides simple changes improving the tex rendering pipeline for `texminted` and `tex`.
It does so largely by relaxing type restrictions in function signatures as well as adding a new `tex_deps` field to the template file that can be used to pass additional packages to be loaded such as `\usepackage{minted}` in the case of `texminted`.